### PR TITLE
fix: changed router pushState and router-view key to re-render component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
     <j-header></j-header>
-    <router-view></router-view>
+    <router-view :key="$route.path"></router-view>
     <j-footer></j-footer>
   </div>
 </template>

--- a/src/pages/Start.vue
+++ b/src/pages/Start.vue
@@ -238,7 +238,12 @@
         this.downloadsWeek = groupData(this.rawData, dateToWeek)
       },
       setURL () {
-        history.pushState({ info: `npm-stats ${this.package}` }, this.package, `/#/${this.package}`)
+        this.$router.push({
+          name: 'Package',
+          params: {
+            package: this.package
+          }
+        })
       },
       toggleSettings () {
         this.showSettings = !this.showSettings

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -15,6 +15,7 @@ export default new Router({
     },
     {
       path: '/:package',
+      name: 'Package',
       component: StartPage
     }
   ]


### PR DESCRIPTION
**The problem?**
On changes of the parameter after /#/ on the router, Start.vue component doesn't re-render itself. This is happening if you go back or forward in history.

In `router-view` was added `:key="$route.path"`. This will re-render the component on router changes, according to path.

In `hash` router mode history API HTML5 isn't working properly. To leverage it, you should use `history` mode of vue router. But if you don't want changes on your server htaccess, just use `$router` methods.
